### PR TITLE
Replace bootstrap list-item-group with custom css for the repository-item

### DIFF
--- a/src/app/repositories/repository-list/repository-item/repository-item.component.html
+++ b/src/app/repositories/repository-list/repository-item/repository-item.component.html
@@ -1,1 +1,1 @@
-<a [routerLink]="'/manifests'" [queryParams]="{'name':repository.name}" class="list-group-item list-group-item-action">{{ repository.name }}</a>
+<a [routerLink]="'/manifests'" [queryParams]="{'name':repository.name}">{{ repository.name }}</a>

--- a/src/app/repositories/repository-list/repository-item/repository-item.component.scss
+++ b/src/app/repositories/repository-list/repository-item/repository-item.component.scss
@@ -1,6 +1,12 @@
-.list-group-item {
-  border: none;
-  padding: 2px;
+a {
+  display: inline-block;
+  width: 100%;
+  color: #495057;
   font-size: 16px;
   font-weight: 500;
+
+  &:hover {
+    background-color: #f8f9fa;
+    text-decoration: none;
+  }
 }

--- a/src/app/repositories/repository-list/repository-list.component.scss
+++ b/src/app/repositories/repository-list/repository-list.component.scss
@@ -2,4 +2,9 @@ div.repository-listing {
   -webkit-column-count: 3;
   -moz-column-count: 3;
   column-count: 3;
+
+  > * {
+    display: block;
+    padding: 2px;
+  }
 }


### PR DESCRIPTION
In new versions of Chrome the list-group-item was rendering very slowly. Maybe
because it was not a direct child of a list-group.

The look should be the same with the new custom CSS as it was with the bootstrap list-item-group.