### PR TITLE
Fix version of ng-bootstrap since prod build fails otherwise

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^4.2.4",
     "@angular/platform-browser-dynamic": "^4.2.4",
     "@angular/router": "^4.2.4",
-    "@ng-bootstrap/ng-bootstrap": "^1.0.0-beta.4",
+    "@ng-bootstrap/ng-bootstrap": "1.0.0-beta.4",
     "angular-linky": "^1.2.2",
     "autolinker": "^1.4.3",
     "bootstrap": "^4.0.0-beta",


### PR DESCRIPTION
Otherwise a version is used that is too new and not compatible with the setup.
ng-bootstrap could actually be completely removed since it is not used.